### PR TITLE
Set get_md5 explicitly to true

### DIFF
--- a/tasks/setup-centos6.yml
+++ b/tasks/setup-centos6.yml
@@ -1,6 +1,7 @@
 ---
 - name: check zoneinfo
   stat: path=/usr/share/zoneinfo/{{ zonename | default('Asia/Tokyo') }}
+  get_md5: true
   register: target_zoneinfo
   tags: [timezone]
 


### PR DESCRIPTION
Ansible 2.5 changes the default from true to false.  This option will be removed in 2.9