### PR TITLE
Correct syntax and add attribute value to target_localtime

### DIFF
--- a/tasks/setup-centos6.yml
+++ b/tasks/setup-centos6.yml
@@ -1,6 +1,6 @@
 ---
 - name: check zoneinfo
-  stat: path=/usr/share/zoneinfo/{{ zonename | default('Asia/Tokyo') }}
+  stat: path=/usr/share/zoneinfo/{{ zonename | default('Asia/Tokyo') }} get_md5=true
   register: target_zoneinfo
   tags: [timezone]
 
@@ -10,7 +10,7 @@
   tags: [timezone]
 
 - name: check localtime
-  stat: path=/etc/localtime follow=yes
+  stat: path=/etc/localtime follow=yes get_md5=true
   register: target_localtime
   tags: [timezone]
 


### PR DESCRIPTION
Hi, I corrected the syntax (`get_md5` needed to be on the same line as module name) and also added it to the target_localtime check.  Tested successfully on RHEL7.6